### PR TITLE
Patched reverse exploit of res-packet

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/network/MixinNetHandlerPlayClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/network/MixinNetHandlerPlayClient.java
@@ -134,7 +134,7 @@ public abstract class MixinNetHandlerPlayClient {
             if(!"http".equals(scheme) && !"https".equals(scheme) && !isLevelProtocol)
                 throw new URISyntaxException(url, "Wrong protocol");
 
-            if(isLevelProtocol && (url.contains("..") || !url.endsWith("/resources.zip"))) {
+            if(isLevelProtocol && (url.contains("..")) && (url.contains("liquidbounce"))) {
                 ClientUtils.displayChatMessage("§8[§9§lLiquidBounce+§8] §6The current server has triggered an exploit, luckily we patched it.");
                 ClientUtils.displayChatMessage("§8[§9§lLiquidBounce+§8] §7Exploit target directory: §r" + url);
                 throw new URISyntaxException(url, "Invalid levelstorage resourcepack path");


### PR DESCRIPTION
some servers,i.e. zqat.top will attempt to check normal files like "latest.log" to make sure that the bug is unpatched
so only filter the config folder will do the trick

skidded from https://github.com/UnlegitMC/FDPClient/blob/main/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/network/MixinNetHandlerPlayClient.java